### PR TITLE
Feature/64 friends list function

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-facebook-login": "^4.1.1",
     "react-modal": "^3.16.1",
     "react-router-dom": "^6.21.1",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "yup": "^1.3.3"
   },
   "devDependencies": {

--- a/src/components/Main/FriendsInOnline/FriendsInOnline.tsx
+++ b/src/components/Main/FriendsInOnline/FriendsInOnline.tsx
@@ -5,14 +5,14 @@ import friendsInOnlineData from "./friendsInOnline.json";
 
 function FriendsInOnline() {
   return (
-    <div className="flex justify-center items-center gap-[2.3rem]">
+    <div className="flex justify-center items-center gap-[2.3rem] w-full">
       <UserCircle>
         <UserCircle.UserImage userImage={test} />
         <UserCircle.UserName userName="me" />
       </UserCircle>
 
       <div
-        className="w-[3rem] h-[3rem] rounded-full flex justify-center items-center"
+        className="w-[3rem] h-[3rem] rounded-full flex justify-center items-center shrink-0"
         style={{
           background: "linear-gradient(180deg, #E5EBF0 0%, #E6F0F9 100%)",
         }}
@@ -20,7 +20,7 @@ function FriendsInOnline() {
         <img src={toggleButton} alt="friends-list toggle button" />
       </div>
 
-      <div className="flex gap-[1.7rem]">
+      <div className="flex gap-[1.7rem] overflow-scroll scrollbar-hide">
         {friendsInOnlineData.friendsInOnlineData.map((friend, index) => (
           <UserCircle key={`${index} ${friend.name}`}>
             <UserCircle.UserImage userImage={friend.image}>

--- a/src/components/Main/FriendsInOnline/FriendsInOnline.tsx
+++ b/src/components/Main/FriendsInOnline/FriendsInOnline.tsx
@@ -1,35 +1,51 @@
+import { useState } from "react";
 import UserCircle from "../UserCircle/UserCircle";
 import test from "@/assets/image/hero.webp";
 import toggleButton from "@/assets/icon/toggle.svg";
 import friendsInOnlineData from "./friendsInOnline.json";
 
 function FriendsInOnline() {
+  const [isShow, setIsShow] = useState(true);
+  const onClick = () => {
+    setIsShow(!isShow);
+  };
   return (
-    <div className="flex justify-center items-center gap-[2.3rem] w-full">
+    <div
+      className={`flex items-center mx-[2rem] max-w-[50.2rem] justify-between
+      ${isShow && "gap-[2.3rem]"}
+  `}
+    >
       <UserCircle>
         <UserCircle.UserImage userImage={test} />
         <UserCircle.UserName userName="me" />
       </UserCircle>
 
-      <div
-        className="w-[3rem] h-[3rem] rounded-full flex justify-center items-center shrink-0"
+      <button
+        onClick={onClick}
+        className="w-[3rem] h-[3rem] rounded-full flex justify-center items-center flex-shrink-0"
         style={{
           background: "linear-gradient(180deg, #E5EBF0 0%, #E6F0F9 100%)",
         }}
       >
-        <img src={toggleButton} alt="friends-list toggle button" />
-      </div>
+        <img
+          src={toggleButton}
+          alt="friends-list toggle button"
+          className={`${!isShow && "rotate-180"}`}
+        />
+      </button>
 
-      <div className="flex gap-[1.7rem] overflow-scroll scrollbar-hide">
-        {friendsInOnlineData.friendsInOnlineData.map((friend, index) => (
-          <UserCircle key={`${index} ${friend.name}`}>
-            <UserCircle.UserImage userImage={friend.image}>
-              <UserCircle.LiveTag />
-            </UserCircle.UserImage>
-            <UserCircle.UserName userName={friend.name} />
-          </UserCircle>
-        ))}
-      </div>
+      {isShow && (
+        <div className="flex gap-[1.7rem] overflow-scroll scrollbar-hide">
+          {friendsInOnlineData.friendsInOnlineData.map((friend, index) => (
+            <UserCircle key={`${index} ${friend.name}`}>
+              <UserCircle.UserImage userImage={friend.image}>
+                <UserCircle.LiveTag />
+              </UserCircle.UserImage>
+              <UserCircle.UserName userName={friend.name} />
+            </UserCircle>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Main/FriendsInOnline/friendsInOnline.json
+++ b/src/components/Main/FriendsInOnline/friendsInOnline.json
@@ -3,6 +3,10 @@
     { "image": "/src/assets/image/temp/user1.jpg", "name": "karennne" },
     { "image": "/src/assets/image/temp/user2.jpg", "name": "kieron_d" },
     { "image": "/src/assets/image/temp/user1.jpg", "name": "craig_love" },
+    { "image": "/src/assets/image/temp/user2.jpg", "name": "zackjohn" },
+    { "image": "/src/assets/image/temp/user1.jpg", "name": "karennne" },
+    { "image": "/src/assets/image/temp/user2.jpg", "name": "kieron_d" },
+    { "image": "/src/assets/image/temp/user1.jpg", "name": "craig_love" },
     { "image": "/src/assets/image/temp/user2.jpg", "name": "zackjohn" }
   ]
 }

--- a/src/components/Main/UserCircle/UserCircle.tsx
+++ b/src/components/Main/UserCircle/UserCircle.tsx
@@ -32,7 +32,7 @@ function UserCircleImage({ userImage, children }: UserCircleImageProps) {
       <img
         src={userImage}
         alt="friends in online"
-        className="absolute w-[5.6rem] h-[5.6rem] top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]  rounded-full bg-orange-300"
+        className="absolute w-[5.6rem] h-[5.6rem] top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]  rounded-full"
       />
 
       {children}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,6 @@ export default {
       }
     },
   },
-  plugins: [],
+  plugins: [require("tailwind-scrollbar-hide")],
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9084,6 +9084,11 @@ synchronous-promise@^2.0.15:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.17.tgz#38901319632f946c982152586f2caf8ddc25c032"
   integrity sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==
 
+tailwind-scrollbar-hide@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz#90b481fb2e204030e3919427416650c54f56f847"
+  integrity sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA==
+
 tailwindcss@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.0.tgz#045a9c474e6885ebd0436354e611a76af1c76839"


### PR DESCRIPTION
🚨 **Pull request 전에 확인해야 할 사항( [x] 체크해주세요 )** 

- [ ]  **반드시 확인할 것!** <br> pull a topic/feature/bugfix branch 에서 dev branch로 PR요청하는지 확인하세요.<br> **master/main에 하시면 안됩니다.**

- [ ]  커밋 또는 모든 커밋의 메시지 스타일이 convention과 일치하는지 확인해주세요.

- [ ] PR작업에 대한 오른쪽의 라벨을 붙여주세요.

## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해  무엇을 왜 수정했는지 간단히 설명해주세요.-->

friends-list 컴포넌트에 들어갈 사용자 이벤트 기능을 추가했습니다.

<!-- 관련있는 #이슈 번호를 적어주세요. 
해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요. -->

closed #64
  
## ✨ 작업 내용
<!-- 작업한 기능 대한 설명을 적어주세요 -->

- friends-list가 범위를 넘어갈 경우 슬라이드가 되도록 하였습니다.
- 토글 버튼 누를시 friends-list 등장, 사라짐 구현하였습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷 또는 gif를 첨부해주세요 -->


## 🔊 리뷰어에게(선택)
<!-- 리뷰어에게 전달할 말을 작성해주세요 -->

![image](https://github.com/TeamTheGenius/TeamTheGenius_Web/assets/52223965/e707893b-21ff-4d80-94f8-fbf3b1f02a54)
![image](https://github.com/TeamTheGenius/TeamTheGenius_Web/assets/52223965/caf340d4-f5a2-455a-ab15-21501fe404de)

하늘색 배경의 토글 버튼을 눌러서 friends-list 컴포넌트를 보여주거나 숨기는 방식입니다.

토글이 바꾸는 것은 isShow 상태이고 isShow가 true일 때는 friends-list 컴포넌트를 보여주고 isShow가 false일 때는 friends-list 컴포넌트를 "애니메이션을 넣어서 "사라지게 하고 싶었습니다.

컴포넌트 자체를 숨기고 생기게 하는 건 애니메이션이 적용이 안될 테니 width를 변화하는 형식으로, isShow 상태일때는 friends-list의 width를 0으로 설정하는 방식으로 하려했으나 아래 사진과 같이 width가 0임에도 무언가가 공간을 차지하고 있습니다.

![image](https://github.com/TeamTheGenius/TeamTheGenius_Web/assets/52223965/c3597661-0d5f-46d9-8af3-2936cb992f23)

검색을 해보았으나 마땅한 답을 찾지 못했습니다.. 혹시 이를 해결할 수 있는 방법이 있을까요?? width가 아닌 다른 방법을 생각해보았으나

토글 버튼을 부모 요소로 relative 주고 friends-list 컴포넌트를 자식 요소로서 absolute 주어서 top, left로 구현하는 방식도 생각하였으나 이는 너무 지저분해질 것 같아서 혹시나 해서 여쭤봅니다..!


## 📚 추가 사항(선택)
