### PR TITLE
Fix: 마이챌린지 에러바운더리 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "proxy": "https://api.gitget.co.kr",
+  "proxy": "http://localhost:8080",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/src/apis/axios/axios.ts
+++ b/src/apis/axios/axios.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const BASE_URL = "https://api.gitget.co.kr/api";
+const BASE_URL = "http://localhost:8080/api";
 
 const instanceConfig = {
   baseURL: BASE_URL,

--- a/src/apis/postPaymentSuccess.ts
+++ b/src/apis/postPaymentSuccess.ts
@@ -21,7 +21,7 @@ const postPaymentSuccess = async ({
   };
 
   await instance
-    .post("https://api.gitget.co.kr/api/payment/toss/success", body, {
+    .post("http://localhost:8080/api/payment/toss/success", body, {
       headers: {
         Authorization: encryptedSecretKey,
       },

--- a/src/components/LogIn/GithubLoginButton/index.tsx
+++ b/src/components/LogIn/GithubLoginButton/index.tsx
@@ -3,7 +3,7 @@ import Button from "@/components/LogIn/Button/Button";
 
 function GithubLoginButton() {
   const GITHUB_REDIRECT_URI =
-    "https://api.gitget.co.kr/oauth2/authorization/github";
+    "http://localhost:8080/oauth2/authorization/github";
 
   const onClick = () => {
     window.location.href = GITHUB_REDIRECT_URI;

--- a/src/components/Main/MyChallenge/MyChallengeActivityList/MyChallengeActivityList.tsx
+++ b/src/components/Main/MyChallenge/MyChallengeActivityList/MyChallengeActivityList.tsx
@@ -1,0 +1,138 @@
+import ChallengeItem from "@/components/Common/ChallengeItem/ChallengeItem";
+import MyChallengeLabel from "@/components/Main/MyChallenge/MyChallengeLabel/MyChallengeLabel";
+import MyChallengeLinkWrap from "@/components/Main/MyChallenge/MyChallengeLinkWrap/MyChallengeLinkWrap";
+import MyChallengeTitle from "@/components/Main/MyChallenge/MyChallengeTitle/MyChallengeTitle";
+import MyChallengeWrap from "@/components/Main/MyChallenge/MyChallengeWrap/MyChallengeWrap";
+import successStamp from "@/assets/icon/success-stamp.svg";
+import { makeBase64IncodedImage } from "@/utils/makeBase64IncodedImage";
+import MyChallengePassItem from "@/components/Main/MyChallenge/MyChallengePass/MyChallengePassItem";
+import CertificationPassModal from "@/components/Main/MyChallenge/MyChallengeModal/CertificationPassModal/CertificationPassModal";
+import { useGetMyActivityChallenges } from "@/hooks/queries/useMyChallengeQuery";
+import CertificationModal from "@/components/Main/MyChallenge/MyChallengeModal/CertificationModal/CertificationModal";
+import { EmptyDataView } from "@/components/Common/EmptyDataView/EmptyDataView";
+import { PATH } from "@/constants/path";
+import { useModalStore } from "@/stores/modalStore";
+
+interface PassItemModal {
+  e: React.MouseEvent;
+  instanceId: number;
+  numOfPassItem: number;
+  itemId: number;
+}
+
+const MyChallengeActivityList = () => {
+  const { setModal } = useModalStore();
+  const { data } = useGetMyActivityChallenges();
+  if (!data) {
+    return;
+  }
+
+  const onClickPassItem = ({
+    e,
+    instanceId,
+    numOfPassItem,
+    itemId,
+  }: PassItemModal) => {
+    e.stopPropagation();
+    setModal(
+      <CertificationPassModal
+        instanceId={instanceId}
+        numOfPassItem={numOfPassItem}
+        itemId={itemId}
+      />
+    );
+  };
+
+  const reNewCertification = async (
+    e: React.MouseEvent,
+    instanceId: number
+  ) => {
+    e.stopPropagation();
+    setModal(<CertificationModal instanceId={instanceId} />);
+  };
+
+  return (
+    <>
+      {!data.length && (
+        <div className="mt-[5rem]">
+          <EmptyDataView>
+            <EmptyDataView.FireHatchIcon />
+            <EmptyDataView.Title title="진행 중인 챌린지가 없습니다" />
+            <EmptyDataView.SubTitle subTitle="새로운 챌린지에 참여해보세요" />
+            <EmptyDataView.Button label="챌린지 구경가기" path={PATH.HOME} />
+          </EmptyDataView>
+        </div>
+      )}
+      <MyChallengeWrap>
+        {data.map((item, index) => {
+          return (
+            <li key={index} className=" mb-[1.3rem] list-none">
+              <MyChallengeLinkWrap instanceId={item.instanceId}>
+                <div className="min-w-[16.4rem] w-[16.4rem]">
+                  <ChallengeItem>
+                    <ChallengeItem.Image
+                      imgSrc={makeBase64IncodedImage({
+                        uri: item.fileResponse.encodedFile,
+                        format: "jpg",
+                      })}
+                      alt={"챌린지 이미지"}
+                      direction="vertical"
+                    >
+                      {item.certificateStatus === "패스 완료" && (
+                        <ChallengeItem.Overlay text="패 스" />
+                      )}
+                      {item.certificateStatus === "인증 갱신" && (
+                        <ChallengeItem.Overlay />
+                      )}
+                      {item.certificateStatus === "인증 갱신" && (
+                        <img
+                          src={successStamp}
+                          alt="성공 스탬프"
+                          className="bottom-[1rem] right-[1rem] absolute"
+                        />
+                      )}
+                    </ChallengeItem.Image>
+                  </ChallengeItem>
+                </div>
+                <div className="w-full justify-between flex flex-col ">
+                  <MyChallengeTitle
+                    title={item.title}
+                    point={item.pointPerPerson}
+                    repositoryName={item.repository}
+                  />
+                  {item.canUsePassItem &&
+                    item.certificateStatus == "인증하기" && (
+                      <MyChallengePassItem
+                        passCount={item.numOfPassItem}
+                        onClick={(e: React.MouseEvent) =>
+                          onClickPassItem({
+                            e: e,
+                            instanceId: item.instanceId,
+                            numOfPassItem: item.numOfPassItem,
+                            itemId: item.itemId,
+                          })
+                        }
+                      />
+                    )}
+                  {item.certificateStatus === "인증 갱신" ||
+                  item.certificateStatus === "인증하기" ? (
+                    <MyChallengeLabel
+                      labelText={item.certificateStatus}
+                      onClick={(e: React.MouseEvent) =>
+                        reNewCertification(e, item.instanceId)
+                      }
+                    />
+                  ) : (
+                    <MyChallengeLabel labelText={item.certificateStatus} />
+                  )}
+                </div>
+              </MyChallengeLinkWrap>
+            </li>
+          );
+        })}
+      </MyChallengeWrap>
+    </>
+  );
+};
+
+export default MyChallengeActivityList;

--- a/src/components/Main/MyChallenge/MyChallengeDoneList/MyChallengeDoneList.tsx
+++ b/src/components/Main/MyChallenge/MyChallengeDoneList/MyChallengeDoneList.tsx
@@ -1,0 +1,134 @@
+import ChallengeItem from "@/components/Common/ChallengeItem/ChallengeItem";
+import MyChallengeLabel from "@/components/Main/MyChallenge/MyChallengeLabel/MyChallengeLabel";
+import MyChallengeLinkWrap from "@/components/Main/MyChallenge/MyChallengeLinkWrap/MyChallengeLinkWrap";
+import GetRewardModal from "@/components/Main/MyChallenge/MyChallengeModal/GetRewardModal/GetRewardModal";
+import AskGetRewardTwiceModal from "@/components/Main/MyChallenge/MyChallengeModal/AskGetRewardTwiceModal/AskGetRewardTwiceModal";
+import MyChallengeTitle from "@/components/Main/MyChallenge/MyChallengeTitle/MyChallengeTitle";
+import MyChallengeWrap from "@/components/Main/MyChallenge/MyChallengeWrap/MyChallengeWrap";
+import { makeBase64IncodedImage } from "@/utils/makeBase64IncodedImage";
+import React from "react";
+import { EmptyDataView } from "@/components/Common/EmptyDataView/EmptyDataView";
+import { useModalStore } from "@/stores/modalStore";
+import { useGetMyDoneChallenges } from "@/hooks/queries/useMyChallengeQuery";
+
+const MyChallengeDoneList = () => {
+  const { setModal } = useModalStore();
+  const { data } = useGetMyDoneChallenges();
+
+  if (!data) {
+    return;
+  }
+
+  const onClickGetRewardButton = async (
+    e: React.MouseEvent,
+    instanceId: number
+  ) => {
+    e.stopPropagation();
+    setModal(<GetRewardModal instanceId={instanceId} />);
+  };
+  const onClickGetRewardTwiceButton = (
+    e: React.MouseEvent,
+    instanceId: number,
+    numOfPointItem: number,
+    itemId: number
+  ) => {
+    e.stopPropagation();
+    setModal(
+      <AskGetRewardTwiceModal
+        numOfPointItem={numOfPointItem}
+        instanceId={instanceId}
+        itemId={itemId}
+      />
+    );
+  };
+  return (
+    <>
+      {!data.length && (
+        <div className="mt-[5rem]">
+          <EmptyDataView>
+            <EmptyDataView.FireHatchIcon />
+            <EmptyDataView.Title title="완료한 챌린지가 없습니다" />
+            <EmptyDataView.SubTitle subTitle="챌린지에 참여해 끝까지 힘내봐요!" />
+          </EmptyDataView>
+        </div>
+      )}
+
+      <MyChallengeWrap>
+        {data.map((item, index) => {
+          return (
+            <li key={index} className="mb-[1.3rem] list-none">
+              <MyChallengeLinkWrap key={index} instanceId={item.instanceId}>
+                <div className="min-w-[16.4rem] w-[16.4rem]">
+                  <ChallengeItem>
+                    <ChallengeItem.Image
+                      imgSrc={makeBase64IncodedImage({
+                        uri: item.fileResponse.encodedFile,
+                        format: "jpg",
+                      })}
+                      alt={"챌린지 이미지"}
+                      direction="vertical"
+                    >
+                      {item.joinResult === "FAIL" && (
+                        <ChallengeItem.Overlay text="실 패" />
+                      )}
+                    </ChallengeItem.Image>
+                  </ChallengeItem>
+                </div>
+
+                <div className="w-full justify-between flex flex-col ">
+                  <MyChallengeTitle
+                    title={item.title}
+                    point={item.pointPerPerson}
+                  />
+                  {!item.canGetReward && (
+                    <div className="flex justify-around w-full">
+                      <div className="flex flex-col">
+                        <span className="text-[#777777] text-[12px] font-medium">
+                          획득 포인트
+                        </span>
+                        <span className="text-black text-[18px] font-medium">
+                          {item.rewardedPoints}P
+                        </span>
+                      </div>
+                      <div className="flex justify-start flex-col">
+                        <span className="text-[#777777] text-[12px] font-medium">
+                          달성률
+                        </span>
+                        <span className="text-black text-[18px] font-medium">
+                          {item.achievementRate}%
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                  {item.canGetReward && item.numOfPointItem === 0 && (
+                    <MyChallengeLabel
+                      labelText="보상 수령"
+                      onClick={(e: React.MouseEvent) =>
+                        onClickGetRewardButton(e, item.instanceId)
+                      }
+                    />
+                  )}
+                  {item.canGetReward && item.numOfPointItem > 0 && (
+                    <MyChallengeLabel
+                      labelText="보상 수령"
+                      onClick={(e: React.MouseEvent) =>
+                        onClickGetRewardTwiceButton(
+                          e,
+                          item.instanceId,
+                          item.numOfPointItem,
+                          item.itemId
+                        )
+                      }
+                    />
+                  )}
+                </div>
+              </MyChallengeLinkWrap>
+            </li>
+          );
+        })}
+      </MyChallengeWrap>
+    </>
+  );
+};
+
+export default MyChallengeDoneList;

--- a/src/components/Main/MyChallenge/MyChallengePreActivityList/MyChallengePreActivityList.tsx
+++ b/src/components/Main/MyChallenge/MyChallengePreActivityList/MyChallengePreActivityList.tsx
@@ -1,0 +1,67 @@
+import MyChallengeLinkWrap from "../MyChallengeLinkWrap/MyChallengeLinkWrap";
+import ChallengeItem from "@/components/Common/ChallengeItem/ChallengeItem";
+import { makeBase64IncodedImage } from "@/utils/makeBase64IncodedImage";
+import MyChallengeTitle from "../MyChallengeTitle/MyChallengeTitle";
+import MyChallengeLabel from "../MyChallengeLabel/MyChallengeLabel";
+import MyChallengeWrap from "../MyChallengeWrap/MyChallengeWrap";
+import { useGetMyPreActivityChallenges } from "@/hooks/queries/useMyChallengeQuery";
+import { EmptyDataView } from "@/components/Common/EmptyDataView/EmptyDataView";
+import { PATH } from "@/constants/path";
+
+function MyChallengePreActivityList() {
+  const { data } = useGetMyPreActivityChallenges();
+  return (
+    <>
+      {!data?.length && (
+        <div className="mt-[5rem]">
+          <EmptyDataView>
+            <EmptyDataView.FireHatchIcon />
+            <EmptyDataView.Title title="시작 전인 챌린지가 없습니다" />
+            <EmptyDataView.SubTitle subTitle="새로운 챌린지에 참여해보세요" />
+            <EmptyDataView.Button label="챌린지 구경가기" path={PATH.HOME} />
+          </EmptyDataView>
+        </div>
+      )}
+      <MyChallengeWrap>
+        {data?.map((item, index) => {
+          return (
+            <li key={index} className="mb-[1.3rem] list-none">
+              <MyChallengeLinkWrap key={index} instanceId={item.instanceId}>
+                <div className="min-w-[16.4rem] w-[16.4rem] h-[12.6rem]">
+                  <ChallengeItem>
+                    <ChallengeItem.Image
+                      imgSrc={makeBase64IncodedImage({
+                        uri: item.fileResponse.encodedFile,
+                        format: "jpg",
+                      })}
+                      alt={"챌린지 이미지"}
+                      direction="vertical"
+                    >
+                      <ChallengeItem.Overlay text={`D - ${item.remainDays}`} />
+                      <ChallengeItem.NumberOfParticipant
+                        numberOfParticipants={item.participantCount}
+                      />
+                    </ChallengeItem.Image>
+                  </ChallengeItem>
+                </div>
+
+                <div className="w-full justify-between flex flex-col ">
+                  <MyChallengeTitle
+                    title={item.title}
+                    point={item.pointPerPerson}
+                  />
+                  <MyChallengeLabel
+                    labelText="시작 전"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+              </MyChallengeLinkWrap>
+            </li>
+          );
+        })}
+      </MyChallengeWrap>
+    </>
+  );
+}
+
+export default MyChallengePreActivityList;

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
 
 html {
   font-size: 62.5%;
+  overflow-y: scroll;
 }
 
 * {
@@ -12,7 +13,6 @@ html {
 
 #root {
   height: 100vh;
-  overflow-y: scroll;
 }
 
 :root {

--- a/src/pages/MyChallenge/MyChallenge.tsx
+++ b/src/pages/MyChallenge/MyChallenge.tsx
@@ -1,11 +1,6 @@
-import { Suspense } from "react";
 import { Outlet } from "react-router-dom";
-import LoadingBox from "@/components/Common/Loading/LoadingBox/LoadingBox";
 import MainHeader from "@/components/Common/MainHeader/MainHeader";
 import MyChallengeTabs from "@/components/Main/MyChallenge/MyChallengeTabs/MyChallengeTabs";
-import { ErrorBoundary } from "react-error-boundary";
-import CommonGetErrorFallback from "@/components/Error/CommonGetErrorFallback/CommonGetErrorFallback";
-import { QueryErrorResetBoundary } from "react-query";
 
 const MyChallenge = () => {
   return (
@@ -16,18 +11,7 @@ const MyChallenge = () => {
       </div>
 
       <div className="px-[2.2rem] pt-[12.5rem] h-full pb-[2rem]">
-        <QueryErrorResetBoundary>
-          {({ reset }) => (
-            <ErrorBoundary
-              onReset={reset}
-              FallbackComponent={CommonGetErrorFallback}
-            >
-              <Suspense fallback={<LoadingBox />}>
-                <Outlet />
-              </Suspense>
-            </ErrorBoundary>
-          )}
-        </QueryErrorResetBoundary>
+        <Outlet />
       </div>
     </>
   );

--- a/src/pages/MyChallenge/MyChallengeComplete/MyChallengeComplete.tsx
+++ b/src/pages/MyChallenge/MyChallengeComplete/MyChallengeComplete.tsx
@@ -1,134 +1,25 @@
-import ChallengeItem from "@/components/Common/ChallengeItem/ChallengeItem";
-import MyChallengeLabel from "@/components/Main/MyChallenge/MyChallengeLabel/MyChallengeLabel";
-import MyChallengeLinkWrap from "@/components/Main/MyChallenge/MyChallengeLinkWrap/MyChallengeLinkWrap";
-import GetRewardModal from "@/components/Main/MyChallenge/MyChallengeModal/GetRewardModal/GetRewardModal";
-import AskGetRewardTwiceModal from "@/components/Main/MyChallenge/MyChallengeModal/AskGetRewardTwiceModal/AskGetRewardTwiceModal";
-import MyChallengeTitle from "@/components/Main/MyChallenge/MyChallengeTitle/MyChallengeTitle";
-import MyChallengeWrap from "@/components/Main/MyChallenge/MyChallengeWrap/MyChallengeWrap";
-import { makeBase64IncodedImage } from "@/utils/makeBase64IncodedImage";
-import React from "react";
-import { EmptyDataView } from "@/components/Common/EmptyDataView/EmptyDataView";
-import { useModalStore } from "@/stores/modalStore";
-import { useGetMyDoneChallenges } from "@/hooks/queries/useMyChallengeQuery";
+import LoadingBox from "@/components/Common/Loading/LoadingBox/LoadingBox";
+import CommonGetErrorFallback from "@/components/Error/CommonGetErrorFallback/CommonGetErrorFallback";
+import MyChallengeDoneList from "@/components/Main/MyChallenge/MyChallengeDoneList/MyChallengeDoneList";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { QueryErrorResetBoundary } from "react-query";
 
-const MyChallengeComplete = () => {
-  const { setModal } = useModalStore();
-  const { data } = useGetMyDoneChallenges();
-
-  if (!data) {
-    return;
-  }
-
-  const onClickGetRewardButton = async (
-    e: React.MouseEvent,
-    instanceId: number
-  ) => {
-    e.stopPropagation();
-    setModal(<GetRewardModal instanceId={instanceId} />);
-  };
-  const onClickGetRewardTwiceButton = (
-    e: React.MouseEvent,
-    instanceId: number,
-    numOfPointItem: number,
-    itemId: number
-  ) => {
-    e.stopPropagation();
-    setModal(
-      <AskGetRewardTwiceModal
-        numOfPointItem={numOfPointItem}
-        instanceId={instanceId}
-        itemId={itemId}
-      />
-    );
-  };
+function MyChallengeComplete() {
   return (
-    <>
-      {!data.length && (
-        <div className="mt-[5rem]">
-          <EmptyDataView>
-            <EmptyDataView.FireHatchIcon />
-            <EmptyDataView.Title title="완료한 챌린지가 없습니다" />
-            <EmptyDataView.SubTitle subTitle="챌린지에 참여해 끝까지 힘내봐요!" />
-          </EmptyDataView>
-        </div>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          FallbackComponent={CommonGetErrorFallback}
+        >
+          <Suspense fallback={<LoadingBox />}>
+            <MyChallengeDoneList />
+          </Suspense>
+        </ErrorBoundary>
       )}
-
-      <MyChallengeWrap>
-        {data.map((item, index) => {
-          return (
-            <li key={index} className="mb-[1.3rem] list-none">
-              <MyChallengeLinkWrap key={index} instanceId={item.instanceId}>
-                <div className="min-w-[16.4rem] w-[16.4rem]">
-                  <ChallengeItem>
-                    <ChallengeItem.Image
-                      imgSrc={makeBase64IncodedImage({
-                        uri: item.fileResponse.encodedFile,
-                        format: "jpg",
-                      })}
-                      alt={"챌린지 이미지"}
-                      direction="vertical"
-                    >
-                      {item.joinResult === "FAIL" && (
-                        <ChallengeItem.Overlay text="실 패" />
-                      )}
-                    </ChallengeItem.Image>
-                  </ChallengeItem>
-                </div>
-
-                <div className="w-full justify-between flex flex-col ">
-                  <MyChallengeTitle
-                    title={item.title}
-                    point={item.pointPerPerson}
-                  />
-                  {!item.canGetReward && (
-                    <div className="flex justify-around w-full">
-                      <div className="flex flex-col">
-                        <span className="text-[#777777] text-[12px] font-medium">
-                          획득 포인트
-                        </span>
-                        <span className="text-black text-[18px] font-medium">
-                          {item.rewardedPoints}P
-                        </span>
-                      </div>
-                      <div className="flex justify-start flex-col">
-                        <span className="text-[#777777] text-[12px] font-medium">
-                          달성률
-                        </span>
-                        <span className="text-black text-[18px] font-medium">
-                          {item.achievementRate}%
-                        </span>
-                      </div>
-                    </div>
-                  )}
-                  {item.canGetReward && item.numOfPointItem === 0 && (
-                    <MyChallengeLabel
-                      labelText="보상 수령"
-                      onClick={(e: React.MouseEvent) =>
-                        onClickGetRewardButton(e, item.instanceId)
-                      }
-                    />
-                  )}
-                  {item.canGetReward && item.numOfPointItem > 0 && (
-                    <MyChallengeLabel
-                      labelText="보상 수령"
-                      onClick={(e: React.MouseEvent) =>
-                        onClickGetRewardTwiceButton(
-                          e,
-                          item.instanceId,
-                          item.numOfPointItem,
-                          item.itemId
-                        )
-                      }
-                    />
-                  )}
-                </div>
-              </MyChallengeLinkWrap>
-            </li>
-          );
-        })}
-      </MyChallengeWrap>
-    </>
+    </QueryErrorResetBoundary>
   );
-};
+}
 
 export default MyChallengeComplete;

--- a/src/pages/MyChallenge/MyChallengeProgress/MyChallengeProgress.tsx
+++ b/src/pages/MyChallenge/MyChallengeProgress/MyChallengeProgress.tsx
@@ -1,138 +1,25 @@
-import ChallengeItem from "@/components/Common/ChallengeItem/ChallengeItem";
-import MyChallengeLabel from "@/components/Main/MyChallenge/MyChallengeLabel/MyChallengeLabel";
-import MyChallengeLinkWrap from "@/components/Main/MyChallenge/MyChallengeLinkWrap/MyChallengeLinkWrap";
-import MyChallengeTitle from "@/components/Main/MyChallenge/MyChallengeTitle/MyChallengeTitle";
-import MyChallengeWrap from "@/components/Main/MyChallenge/MyChallengeWrap/MyChallengeWrap";
-import successStamp from "@/assets/icon/success-stamp.svg";
-import { makeBase64IncodedImage } from "@/utils/makeBase64IncodedImage";
-import MyChallengePassItem from "@/components/Main/MyChallenge/MyChallengePass/MyChallengePassItem";
-import CertificationPassModal from "@/components/Main/MyChallenge/MyChallengeModal/CertificationPassModal/CertificationPassModal";
-import { useGetMyActivityChallenges } from "@/hooks/queries/useMyChallengeQuery";
-import CertificationModal from "@/components/Main/MyChallenge/MyChallengeModal/CertificationModal/CertificationModal";
-import { EmptyDataView } from "@/components/Common/EmptyDataView/EmptyDataView";
-import { PATH } from "@/constants/path";
-import { useModalStore } from "@/stores/modalStore";
+import LoadingBox from "@/components/Common/Loading/LoadingBox/LoadingBox";
+import CommonGetErrorFallback from "@/components/Error/CommonGetErrorFallback/CommonGetErrorFallback";
+import MyChallengeActivityList from "@/components/Main/MyChallenge/MyChallengeActivityList/MyChallengeActivityList";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { QueryErrorResetBoundary } from "react-query";
 
-interface PassItemModal {
-  e: React.MouseEvent;
-  instanceId: number;
-  numOfPassItem: number;
-  itemId: number;
-}
-
-const MyChallengeProgress = () => {
-  const { setModal } = useModalStore();
-  const { data } = useGetMyActivityChallenges();
-  if (!data) {
-    return;
-  }
-
-  const onClickPassItem = ({
-    e,
-    instanceId,
-    numOfPassItem,
-    itemId,
-  }: PassItemModal) => {
-    e.stopPropagation();
-    setModal(
-      <CertificationPassModal
-        instanceId={instanceId}
-        numOfPassItem={numOfPassItem}
-        itemId={itemId}
-      />
-    );
-  };
-
-  const reNewCertification = async (
-    e: React.MouseEvent,
-    instanceId: number
-  ) => {
-    e.stopPropagation();
-    setModal(<CertificationModal instanceId={instanceId} />);
-  };
-
+function MyChallengeProgress() {
   return (
-    <>
-      {!data.length && (
-        <div className="mt-[5rem]">
-          <EmptyDataView>
-            <EmptyDataView.FireHatchIcon />
-            <EmptyDataView.Title title="진행 중인 챌린지가 없습니다" />
-            <EmptyDataView.SubTitle subTitle="새로운 챌린지에 참여해보세요" />
-            <EmptyDataView.Button label="챌린지 구경가기" path={PATH.HOME} />
-          </EmptyDataView>
-        </div>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          FallbackComponent={CommonGetErrorFallback}
+        >
+          <Suspense fallback={<LoadingBox />}>
+            <MyChallengeActivityList />
+          </Suspense>
+        </ErrorBoundary>
       )}
-      <MyChallengeWrap>
-        {data.map((item, index) => {
-          return (
-            <li key={index} className=" mb-[1.3rem] list-none">
-              <MyChallengeLinkWrap instanceId={item.instanceId}>
-                <div className="min-w-[16.4rem] w-[16.4rem]">
-                  <ChallengeItem>
-                    <ChallengeItem.Image
-                      imgSrc={makeBase64IncodedImage({
-                        uri: item.fileResponse.encodedFile,
-                        format: "jpg",
-                      })}
-                      alt={"챌린지 이미지"}
-                      direction="vertical"
-                    >
-                      {item.certificateStatus === "패스 완료" && (
-                        <ChallengeItem.Overlay text="패 스" />
-                      )}
-                      {item.certificateStatus === "인증 갱신" && (
-                        <ChallengeItem.Overlay />
-                      )}
-                      {item.certificateStatus === "인증 갱신" && (
-                        <img
-                          src={successStamp}
-                          alt="성공 스탬프"
-                          className="bottom-[1rem] right-[1rem] absolute"
-                        />
-                      )}
-                    </ChallengeItem.Image>
-                  </ChallengeItem>
-                </div>
-                <div className="w-full justify-between flex flex-col ">
-                  <MyChallengeTitle
-                    title={item.title}
-                    point={item.pointPerPerson}
-                    repositoryName={item.repository}
-                  />
-                  {item.canUsePassItem &&
-                    item.certificateStatus == "인증하기" && (
-                      <MyChallengePassItem
-                        passCount={item.numOfPassItem}
-                        onClick={(e: React.MouseEvent) =>
-                          onClickPassItem({
-                            e: e,
-                            instanceId: item.instanceId,
-                            numOfPassItem: item.numOfPassItem,
-                            itemId: item.itemId,
-                          })
-                        }
-                      />
-                    )}
-                  {item.certificateStatus === "인증 갱신" ||
-                  item.certificateStatus === "인증하기" ? (
-                    <MyChallengeLabel
-                      labelText={item.certificateStatus}
-                      onClick={(e: React.MouseEvent) =>
-                        reNewCertification(e, item.instanceId)
-                      }
-                    />
-                  ) : (
-                    <MyChallengeLabel labelText={item.certificateStatus} />
-                  )}
-                </div>
-              </MyChallengeLinkWrap>
-            </li>
-          );
-        })}
-      </MyChallengeWrap>
-    </>
+    </QueryErrorResetBoundary>
   );
-};
+}
 
 export default MyChallengeProgress;

--- a/src/pages/MyChallenge/MyChallengeStart/MyChallengeStart.tsx
+++ b/src/pages/MyChallenge/MyChallengeStart/MyChallengeStart.tsx
@@ -1,67 +1,24 @@
-import MyChallengeWrap from "@/components/Main/MyChallenge/MyChallengeWrap/MyChallengeWrap";
-import MyChallengeTitle from "@/components/Main/MyChallenge/MyChallengeTitle/MyChallengeTitle";
-import MyChallengeLinkWrap from "@/components/Main/MyChallenge/MyChallengeLinkWrap/MyChallengeLinkWrap";
-import MyChallengeLabel from "@/components/Main/MyChallenge/MyChallengeLabel/MyChallengeLabel";
-import ChallengeItem from "@/components/Common/ChallengeItem/ChallengeItem";
-import { makeBase64IncodedImage } from "@/utils/makeBase64IncodedImage";
-import { useGetMyPreActivityChallenges } from "@/hooks/queries/useMyChallengeQuery";
-import { EmptyDataView } from "@/components/Common/EmptyDataView/EmptyDataView";
-import { PATH } from "@/constants/path";
+import LoadingBox from "@/components/Common/Loading/LoadingBox/LoadingBox";
+import CommonGetErrorFallback from "@/components/Error/CommonGetErrorFallback/CommonGetErrorFallback";
+import MyChallengePreActivityList from "@/components/Main/MyChallenge/MyChallengePreActivityList/MyChallengePreActivityList";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { QueryErrorResetBoundary } from "react-query";
 
 const MyChallengeStart = () => {
-  const { data } = useGetMyPreActivityChallenges();
-
   return (
-    <>
-      {!data?.length && (
-        <div className="mt-[5rem]">
-          <EmptyDataView>
-            <EmptyDataView.FireHatchIcon />
-            <EmptyDataView.Title title="시작 전인 챌린지가 없습니다" />
-            <EmptyDataView.SubTitle subTitle="새로운 챌린지에 참여해보세요" />
-            <EmptyDataView.Button label="챌린지 구경가기" path={PATH.HOME} />
-          </EmptyDataView>
-        </div>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          FallbackComponent={CommonGetErrorFallback}
+        >
+          <Suspense fallback={<LoadingBox />}>
+            <MyChallengePreActivityList />
+          </Suspense>
+        </ErrorBoundary>
       )}
-      <MyChallengeWrap>
-        {data?.map((item, index) => {
-          return (
-            <li key={index} className="mb-[1.3rem] list-none">
-              <MyChallengeLinkWrap key={index} instanceId={item.instanceId}>
-                <div className="min-w-[16.4rem] w-[16.4rem] h-[12.6rem]">
-                  <ChallengeItem>
-                    <ChallengeItem.Image
-                      imgSrc={makeBase64IncodedImage({
-                        uri: item.fileResponse.encodedFile,
-                        format: "jpg",
-                      })}
-                      alt={"챌린지 이미지"}
-                      direction="vertical"
-                    >
-                      <ChallengeItem.Overlay text={`D - ${item.remainDays}`} />
-                      <ChallengeItem.NumberOfParticipant
-                        numberOfParticipants={item.participantCount}
-                      />
-                    </ChallengeItem.Image>
-                  </ChallengeItem>
-                </div>
-
-                <div className="w-full justify-between flex flex-col ">
-                  <MyChallengeTitle
-                    title={item.title}
-                    point={item.pointPerPerson}
-                  />
-                  <MyChallengeLabel
-                    labelText="시작 전"
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                </div>
-              </MyChallengeLinkWrap>
-            </li>
-          );
-        })}
-      </MyChallengeWrap>
-    </>
+    </QueryErrorResetBoundary>
   );
 };
 

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -4,7 +4,7 @@ export default (app) => {
   app.use(
     "/api",
     createProxyMiddleware({
-      target: "https://api.gitget.co.kr",
+      target: "http://localhost:8080",
       changeOrigin: true,
     })
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9128,8 +9128,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9161,8 +9169,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9986,8 +10000,16 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Related to: #401

🚨 **Pull request 전에 확인해야 할 사항( [x] 체크해주세요 )** 

- [x]  **반드시 확인할 것!** <br> pull a topic/feature/bugfix branch 에서 dev branch로 PR요청하는지 확인하세요.<br> **master/main에 하시면 안됩니다.**

- [x]  커밋 또는 모든 커밋의 메시지 스타일이 convention과 일치하는지 확인해주세요.

- [x] PR작업에 대한 오른쪽의 라벨을 붙여주세요.

## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해  무엇을 왜 수정했는지 간단히 설명해주세요.-->
마이챌린지 페이지 시작 전/ 진행중/ 완료 탭 마다의 에러 바운더리를 분리해주었습니다.
시작 전 탭에서 에러가 발생해 fallback 컴포넌트가 띄워지면 다른 진행중/완료 탭으로 가도 에러 바운더리의 fallback 컴포넌트가 리셋되지 않고 그대로 남아있는 현상을 수정하기 위해서입니다.

<!-- 관련있는 #이슈 번호를 적어주세요. 
해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요. -->
#401 
  
## ✨ 작업 내용
<!-- 작업한 기능 대한 설명을 적어주세요 -->
- [x] 마이챌린지 시작 전 에러바운더리 분리
- [x] 마이챌린지 진행중 에러바운더리 분리
- [x] 마이챌린지 완료 에러바운더리 분리

## 📸 스크린샷(선택)
<!-- 스크린샷 또는 gif를 첨부해주세요 -->

## 🔊 리뷰어에게(선택)
<!-- 리뷰어에게 전달할 말을 작성해주세요 -->

## 📚 추가 사항(선택)
